### PR TITLE
Enable "Text Messages" menu in channels

### DIFF
--- a/Config/config.php
+++ b/Config/config.php
@@ -52,4 +52,22 @@ return [
             ],
         ],
     ],
+    'menu' => [
+        'main' => [
+            'items' => [
+                'mautic.sms.smses' => [
+                    'route'  => 'mautic_sms_index',
+                    'access' => ['sms:smses:viewown', 'sms:smses:viewother'],
+                    'parent' => 'mautic.core.channels',
+                    'checks' => [
+                        'integration' => [
+                            'MauticSmsGateway' => [
+                                'enabled' => true,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ],
 ];


### PR DESCRIPTION
The above change enables the "Text Messages" menu in channels section of Mautic which is responsible to prepare template SMSs